### PR TITLE
Bump upper bounds of package dependencies.

### DIFF
--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -85,7 +85,7 @@ library
   hs-source-dirs:   src
   build-depends:
       base        >=4.5    && <4.20
-    , QuickCheck  >=2.14.1 && <2.14.4
+    , QuickCheck  >=2.14.1 && <2.16
     , splitmix    >=0.0.2  && <0.2
 
   build-depends:

--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -92,7 +92,7 @@ library
       array                 >=0.4.0.0  && <0.6
     , bytestring            >=0.9.2.1  && <0.13
     , case-insensitive      >=1.2.0.4  && <1.3
-    , containers            >=0.4.2.1  && <0.7
+    , containers            >=0.4.2.1  && <0.8
     , data-fix              >=0.3      && <0.4
     , hashable              >=1.2.7.0  && <1.5
     , integer-logarithms    >=1.0.3    && <1.1


### PR DESCRIPTION
This PR makes the following adjustments to upper bounds of dependencies:

```patch
-   , containers  >=0.4.2.1 && <0.7
+   , containers  >=0.4.2.1 && <0.8
```
```patch
-   , QuickCheck  >=2.14.1  && <2.14.4
+   , QuickCheck  >=2.14.1  && <2.16
```

Tested with:
```hs
cabal test all --constraint=containers==0.7 --constraint=QuickCheck==2.15
```

Fixes #92